### PR TITLE
CLI fixes

### DIFF
--- a/mDeepFRI/cli.py
+++ b/mDeepFRI/cli.py
@@ -148,6 +148,13 @@ def get_models(ctx, output):
     help="Remove intermediate files.",
 )
 @click.option(
+    "--overwrite",
+    default=False,
+    type=bool,
+    is_flag=True,
+    help="Overwrite existing files.",
+)
+@click.option(
     "-t",
     "--threads",
     default=1,
@@ -160,7 +167,7 @@ def predict_function(ctx, input, db_path, weights, output, processing_modes,
                      mmseqs_min_bit_score, mmseqs_max_evalue,
                      mmseqs_min_identity, top_k, alignment_gap_open,
                      alignment_gap_extend, alignment_min_identity,
-                     remove_intermediate, threads):
+                     remove_intermediate, overwrite, threads):
     """Predict protein function from sequence."""
     logger.info("Starting Metagenomic-DeepFRI.")
 
@@ -183,4 +190,5 @@ def predict_function(ctx, input, db_path, weights, output, processing_modes,
         alignment_gap_continuation=alignment_gap_extend,
         identity_threshold=alignment_min_identity,
         remove_intermediate=remove_intermediate,
+        overwrite=overwrite,
         threads=threads)

--- a/mDeepFRI/cli.py
+++ b/mDeepFRI/cli.py
@@ -141,9 +141,11 @@ def get_models(ctx, output):
     help="Minimum identity for contact map alignment.",
 )
 @click.option(
-    "--keep-intermediate/--no-keep-intermediate",
-    default=True,
-    help="Keep intermediate files. Default is True.",
+    "--remove-intermediate",
+    default=False,
+    type=bool,
+    is_flag=True,
+    help="Remove intermediate files.",
 )
 @click.option(
     "-t",
@@ -158,7 +160,7 @@ def predict_function(ctx, input, db_path, weights, output, processing_modes,
                      mmseqs_min_bit_score, mmseqs_max_evalue,
                      mmseqs_min_identity, top_k, alignment_gap_open,
                      alignment_gap_extend, alignment_min_identity,
-                     keep_intermediate, threads):
+                     remove_intermediate, threads):
     """Predict protein function from sequence."""
     logger.info("Starting Metagenomic-DeepFRI.")
 
@@ -180,9 +182,5 @@ def predict_function(ctx, input, db_path, weights, output, processing_modes,
         alignment_gap_open=alignment_gap_open,
         alignment_gap_continuation=alignment_gap_extend,
         identity_threshold=alignment_min_identity,
-        keep_intermediate=keep_intermediate,
+        remove_intermediate=remove_intermediate,
         threads=threads)
-
-
-if __name__ == "__main__":
-    main()

--- a/mDeepFRI/database.py
+++ b/mDeepFRI/database.py
@@ -3,7 +3,8 @@ import logging
 from pathlib import Path
 
 from mDeepFRI import MERGED_SEQUENCES, TARGET_MMSEQS_DB_NAME
-from mDeepFRI.mmseqs import create_target_database, extract_fasta_foldcomp
+from mDeepFRI.mmseqs import (check_mmseqs_database, create_target_database,
+                             extract_fasta_foldcomp)
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -45,7 +46,8 @@ def build_database(
         extract_fasta_foldcomp(input_path, output_sequences, threads)
         logging.info("FASTA file extracted to %s", output_sequences)
 
-    if (output_path / TARGET_MMSEQS_DB_NAME).exists():
+    # create mmseqs db
+    if check_mmseqs_database(output_path / TARGET_MMSEQS_DB_NAME):
         logging.info("Found %s in %s", TARGET_MMSEQS_DB_NAME, output_path)
         logging.info("Skipping creation of MMSeqs2 database.")
     else:

--- a/mDeepFRI/database.py
+++ b/mDeepFRI/database.py
@@ -47,7 +47,8 @@ def build_database(
         logging.info("FASTA file extracted to %s", output_sequences)
 
     # create mmseqs db
-    if check_mmseqs_database(output_path / TARGET_MMSEQS_DB_NAME):
+    target_db = check_mmseqs_database(output_path / TARGET_MMSEQS_DB_NAME)
+    if not target_db:
         logging.info("Found %s in %s", TARGET_MMSEQS_DB_NAME, output_path)
         logging.info("Skipping creation of MMSeqs2 database.")
     else:

--- a/mDeepFRI/database.py
+++ b/mDeepFRI/database.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 def build_database(
     input_path: str,
     output_path: str,
+    overwrite: bool,
     threads: int,
 ) -> None:
     """
@@ -25,6 +26,7 @@ def build_database(
     Args:
         input_path (str): path to a FoldComp database with compressed structures.
         output_path (str): path to folder where the database for DeepFRI will be created.
+        overwrite (bool): overwrite existing database.
         threads (int): number of threads to use.
 
     Returns:
@@ -37,7 +39,7 @@ def build_database(
     output_path.mkdir(parents=True, exist_ok=True)
     output_sequences = output_path / MERGED_SEQUENCES
     # check if files exist in output directory
-    if output_sequences.exists():
+    if output_sequences.exists() and not overwrite:
         logging.info("Found %s in %s", MERGED_SEQUENCES, output_path)
         logging.info(
             "Skipping extraction of FASTA file from FoldComp database.")
@@ -48,7 +50,7 @@ def build_database(
 
     # create mmseqs db
     target_db = check_mmseqs_database(output_path / TARGET_MMSEQS_DB_NAME)
-    if not target_db:
+    if not target_db and not overwrite:
         logging.info("Found %s in %s", TARGET_MMSEQS_DB_NAME, output_path)
         logging.info("Skipping creation of MMSeqs2 database.")
     else:

--- a/mDeepFRI/mmseqs.py
+++ b/mDeepFRI/mmseqs.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import tempfile
 from functools import partial
 from multiprocessing.pool import ThreadPool
@@ -7,7 +8,7 @@ from pathlib import Path
 import numpy as np
 
 import mDeepFRI
-from mDeepFRI import MMSEQS_SEARCH_RESULTS
+from mDeepFRI import MMSEQS_SEARCH_RESULTS, TARGET_MMSEQS_DB_NAME
 from mDeepFRI.utils import run_command
 
 MMSEQS_COLUMN_NAMES = [
@@ -87,6 +88,36 @@ def create_target_database(foldcomp_fasta_path: str,
     createdb(foldcomp_fasta_path, mmseqs_db_path)
     logger.info("Indexing new target mmseqs2 database %s", mmseqs_db_path)
     createindex(mmseqs_db_path)
+
+
+def check_mmseqs_database(database: Path):
+    """
+    Check if MMSeqs2 database is intact.
+
+    Args:
+        query_file (pathlib.Path): Path to a query file with protein sequences.
+        database (pathlib.Path): Path to a directory with a pre-built database.
+        output_path (pathlib.Path): Path to a directory where results will be saved.
+
+    Raises:
+        FileNotFoundError: MMSeqs2 database appears to be corrupted.
+
+    Returns:
+        target_db (pathlib.Path): Path to MMSeqs2 database.
+    """
+
+    # Verify all the files for MMSeqs2 database
+    mmseqs2_ext = [
+        ".index", ".dbtype", "_h", "_h.index", "_h.dbtype", ".idx",
+        ".idx.index", ".idx.dbtype", ".lookup", ".source"
+    ]
+
+    target_db = Path(database / TARGET_MMSEQS_DB_NAME)
+    for ext in mmseqs2_ext:
+        if not os.path.isfile(f"{target_db}{ext}"):
+            target_db = None
+
+    return target_db
 
 
 def run_mmseqs_search(query_file: str,

--- a/mDeepFRI/pipeline.py
+++ b/mDeepFRI/pipeline.py
@@ -132,7 +132,7 @@ def predict_protein_function(
         alignment_gap_open: float = 10,
         alignment_gap_continuation: float = 1,
         identity_threshold: float = 0.3,
-        keep_intermediate=True,
+        remove_intermediate=False,
         threads: int = 1):
 
     MAX_SEQ_LEN = 1000
@@ -251,7 +251,7 @@ def predict_protein_function(
 
     output_buffer.close()
 
-    if not keep_intermediate:
+    if remove_intermediate:
         remove_temporary(intermediate)
 
     logging.info("meta-DeepFRI finished successfully.")

--- a/mDeepFRI/pipeline.py
+++ b/mDeepFRI/pipeline.py
@@ -133,6 +133,7 @@ def predict_protein_function(
         alignment_gap_continuation: float = 1,
         identity_threshold: float = 0.3,
         remove_intermediate=False,
+        overwrite=False,
         threads: int = 1):
 
     MAX_SEQ_LEN = 1000
@@ -145,6 +146,7 @@ def predict_protein_function(
     intermediate = build_database(
         input_path=database,
         output_path=database.parent,
+        overwrite=overwrite,
         threads=threads,
     )
 


### PR DESCRIPTION
- add a blocking `subprocess.run` instead of non-blockin `subprocess.Popen` - app needs to wait for the output files before proceeding
- unify logic for checking the mmseqs database 
- add an option to `overwrite` databases - impossible to capture process failure in mmseqs and foldcomp, rebuilding databases will help